### PR TITLE
stopping manager questions from clearing when adding them

### DIFF
--- a/client/src/pages/Reports/ModifyReports/CreateReport.js
+++ b/client/src/pages/Reports/ModifyReports/CreateReport.js
@@ -323,9 +323,6 @@ class CreateReport extends Component {
 
     this.setState({
       managerResponses:[this.state.resOne,this.state.resTwo,this.state.resThree,this.state.resFour],
-      resOne:"",
-      resTwo:"",
-      resThree:""
     })
 
     console.log(this.state.managerResponses)


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

when adding manager questions it clears the text field and then poses a bug that the manager questions have to be answered before the poll gets sent out. This allows the questions to stay within the input field to complete the poll with the manager questions.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] There are no merge conflicts
