### PR TITLE
Manager polls now displaying for users

### DIFF
--- a/client/src/pages/Reports/MemberReports/MemberResponseForm.js
+++ b/client/src/pages/Reports/MemberReports/MemberResponseForm.js
@@ -264,7 +264,7 @@ class MemberResponseForm extends Component {
     console.log('submitted')
     this.completeSurvey()
     this.submitReport();
-    // this.reload()
+    this.reload()
   }
 
 }

--- a/client/src/pages/Reports/MemberReports/ReportResults.css
+++ b/client/src/pages/Reports/MemberReports/ReportResults.css
@@ -157,6 +157,7 @@
 	border: 1px dashed rgb(226, 226, 226);
 	padding: 25px;
 	margin-top: -20px;
+	margin-bottom: 20px;
 }
 
 .calendar-top {

--- a/client/src/pages/Reports/MemberReports/ReportResults.css
+++ b/client/src/pages/Reports/MemberReports/ReportResults.css
@@ -206,6 +206,12 @@
 	padding: 18px;
 }
 
+.manager-feedback-for-users {
+	text-align: left;
+	padding: 18px;
+}
+
+
 .manager-question {
 	text-align: left;
 	font-size: 14px;

--- a/client/src/pages/Reports/MemberReports/ReportResults.js
+++ b/client/src/pages/Reports/MemberReports/ReportResults.js
@@ -44,6 +44,7 @@ class ReportResults extends Component {
     isComplete:false,
     isSentiment: false,
     secondaryPage: true,
+    isManagerActivated: true,
     percentComplete: 0,
     historicalSubmissionRate: 0,
     managerQuestions: [],
@@ -102,9 +103,9 @@ class ReportResults extends Component {
             secondaryPage={this.state.secondaryPage}
           />
 
-          {token.roles != "admin"  ? 
+          {token.roles != "admin" && this.state.isManagerActivated ? 
             <div className="confirm-response" >
-                 {managerToday != today ? "No manager response has been recorded for today" : 
+                 {managerToday != today ? "Poll unavailable: No manager response has been recorded for today" : 
                   <>
                   <div classname="manager-feedback-for-users">
                     <div className="poll-header">
@@ -128,7 +129,18 @@ class ReportResults extends Component {
                   </div>
                     </> }
                 </div>
-            : null } 
+            : 
+            
+            managerToday != today ?  <div
+            className="response-card"
+            interactive={false}
+            elevation={Elevation.TWO}
+          >
+            <MemberResponseForm
+              {...this.props}
+              updateWithUserResponse={this.updateWithManagerResponse}
+            /> 
+        </div> : null } 
 
           {this.state.filteredResponse.length > 0 ||
           this.state.managerCompleted === true ? (
@@ -156,16 +168,17 @@ class ReportResults extends Component {
             </>
           ) : (
             <>
-              <div
-                className="response-card"
-                interactive={false}
-                elevation={Elevation.TWO}
-              >
-                <MemberResponseForm
-                  {...this.props}
-                  updateWithUserResponse={this.updateWithManagerResponse}
-                />
-              </div>
+              {managerToday == today ?
+                <div
+                  className="response-card"
+                  interactive={false}
+                  elevation={Elevation.TWO}
+                >
+                  <MemberResponseForm
+                    {...this.props}
+                    updateWithUserResponse={this.updateWithManagerResponse}
+                  /> 
+              </div> : null} 
               <div className="linebr" />
             </>
           )}
@@ -340,7 +353,7 @@ class ReportResults extends Component {
            submitted_date: feedback.submitted_date }); 
        
       })
-      console.log(managerRes.data)
+      console.log(reportRes.data.report.managerQuestions)
 
       // managerRes.data.map(res => {
       //   console.log(res)
@@ -366,6 +379,7 @@ class ReportResults extends Component {
           });
       });
       this.setState({
+        isManagerActivated: reportRes.data.report.managerQuestions,
         isSentiment,
         responses: responsesRes.data,
         filteredResponse: filtered,
@@ -376,7 +390,6 @@ class ReportResults extends Component {
         // managerSubmitted: managerSubmitted,
         managerFeedback: managerFeedback,
       });
-      console.log(managerFeedback)
     } catch (err) {
       console.log(err);
     }

--- a/client/src/pages/Reports/MemberReports/ReportResults.js
+++ b/client/src/pages/Reports/MemberReports/ReportResults.js
@@ -40,6 +40,7 @@ class ReportResults extends Component {
     clickedResponder: null,
     responders: [],
     completed: false,
+    managerCompleted: false,
     isComplete:false,
     isSentiment: false,
     secondaryPage: true,
@@ -77,7 +78,7 @@ class ReportResults extends Component {
     }
     
 
-    console.log(managerPollDays)
+    console.log(this.state.managerQuestions)
     
     //calculating date of the manager report 
     const token = jwt_decode(localStorage.getItem('token'));
@@ -94,14 +95,43 @@ class ReportResults extends Component {
     return (
       <div className="dashboard-view">
         <main className="view">
+          
           <PageTitle
             title="Report"
             {...this.props}
             secondaryPage={this.state.secondaryPage}
           />
 
+          {token.roles != "admin"  ? 
+            <div className="confirm-response" >
+                 {managerToday != today ? "No manager response has been recorded for today" : 
+                  <>
+                  <div classname="manager-feedback-for-users">
+                    <div className="poll-header">
+                    <div className="member-form-title">Manager View</div>
+                    <p className="member-form-subtitle">
+                      View your manager's responses to his poll to guide your responses and goals for the day
+                    </p>
+                  </div>
+                  <div className="vertical-line" />
+
+                    <div className= "manager-question">{managerPollDays[managerPollDays.length-1].managerQuestions[0]}</div> 
+                    <div className= "manager-response">{managerPollDays[managerPollDays.length-1].managerResponses[0]}</div> 
+                    <div className= "manager-question">{managerPollDays[managerPollDays.length-1].managerQuestions[1]}</div> 
+                    <div className= "manager-response">{managerPollDays[managerPollDays.length-1].managerResponses[1]}</div> 
+                    <div className= "manager-question">{managerPollDays[managerPollDays.length-1].managerQuestions[2]}</div> 
+                    <div className= "manager-response">{managerPollDays[managerPollDays.length-1].managerResponses[2]}</div> 
+                    {managerPollDays[managerPollDays.length-1].managerQuestions.length === 4 ? <>
+                      <div className= "manager-question">{managerPollDays[managerPollDays.length-1].managerQuestions[3]}</div> 
+                      <div className= "manager-response">{managerPollDays[managerPollDays.length-1].managerResponses[3]}</div></> : null }
+
+                  </div>
+                    </> }
+                </div>
+            : null } 
+
           {this.state.filteredResponse.length > 0 ||
-          this.state.completed === true ? (
+          this.state.managerCompleted === true ? (
             <>
               <div className="confirm-response">
                 {managerToday != today  ?  "Your response has been recorded ": 
@@ -133,7 +163,7 @@ class ReportResults extends Component {
               >
                 <MemberResponseForm
                   {...this.props}
-                  updateWithUserResponse={this.updateWithUserResponse}
+                  updateWithUserResponse={this.updateWithManagerResponse}
                 />
               </div>
               <div className="linebr" />
@@ -373,6 +403,13 @@ class ReportResults extends Component {
   updateWithUserResponse = res => {
     this.setState({ responses: res.data, 
                     completed: true,
+                    isComplete: true
+                  });
+  };
+
+  updateWithUserResponse = res => {
+    this.setState({ responses: res.data, 
+                    managerCompleted: true,
                     isComplete: true
                   });
   };

--- a/client/src/pages/Reports/MemberReports/ReportResults.js
+++ b/client/src/pages/Reports/MemberReports/ReportResults.js
@@ -12,6 +12,8 @@ import Slider from "@material-ui/lab/Slider";
 import { withStyles } from "@material-ui/core/styles";
 import CircleProgress from "../../../components/circleProgress.js";
 import { Card, Elevation } from "@blueprintjs/core";
+import ToggleOn from "../../../images/icons/chevron-down.png";
+import ToggleOff from "../../../images/icons/chevron-up.png";
 
 import "./ReportResults.css";
 
@@ -115,7 +117,13 @@ class ReportResults extends Component {
                   <>
                   <div classname="manager-feedback-for-users" onClick = {this.toggleManagerQ}>
                     <div className="poll-header">
-                    <div className="member-form-title">Manager Comments</div>
+                      <div className = "toggle-manager-questions">
+                          <div className="member-form-title">Manager Comments</div>
+                          <img
+                          className="manager-toggle"
+                          src={this.state.seeMangerQ ? ToggleOff : ToggleOn }
+                        />
+                       </div>
                     <p className="member-form-subtitle">
                       View your manager's responses to his poll to guide your responses and goals for the day
                     </p>

--- a/client/src/pages/Reports/MemberReports/ReportResults.js
+++ b/client/src/pages/Reports/MemberReports/ReportResults.js
@@ -51,8 +51,14 @@ class ReportResults extends Component {
     managerResponses: [], 
     managerSubmitted: [],
     managerFeedback: [],
+    seeManagerQ: true, 
   };
 
+  toggleManagerQ = () => {
+    this.setState({
+      seeManagerQ: !this.state.seeManagerQ
+    });
+  };
 
   getDate = (date) => {
     let formatted = moment(date).format('DD MMMM YYYY');
@@ -107,15 +113,15 @@ class ReportResults extends Component {
             <div className="confirm-response" >
                  {managerToday != today ? "Poll unavailable: No manager response has been recorded for today" : 
                   <>
-                  <div classname="manager-feedback-for-users">
+                  <div classname="manager-feedback-for-users" onClick = {this.toggleManagerQ}>
                     <div className="poll-header">
-                    <div className="member-form-title">Manager View</div>
+                    <div className="member-form-title">Manager Comments</div>
                     <p className="member-form-subtitle">
                       View your manager's responses to his poll to guide your responses and goals for the day
                     </p>
                   </div>
-                  <div className="vertical-line" />
-
+                    {this.state.seeManagerQ ? <> 
+                      <div className="vertical-line" />
                     <div className= "manager-question">{managerPollDays[managerPollDays.length-1].managerQuestions[0]}</div> 
                     <div className= "manager-response">{managerPollDays[managerPollDays.length-1].managerResponses[0]}</div> 
                     <div className= "manager-question">{managerPollDays[managerPollDays.length-1].managerQuestions[1]}</div> 
@@ -124,7 +130,7 @@ class ReportResults extends Component {
                     <div className= "manager-response">{managerPollDays[managerPollDays.length-1].managerResponses[2]}</div> 
                     {managerPollDays[managerPollDays.length-1].managerQuestions.length === 4 ? <>
                       <div className= "manager-question">{managerPollDays[managerPollDays.length-1].managerQuestions[3]}</div> 
-                      <div className= "manager-response">{managerPollDays[managerPollDays.length-1].managerResponses[3]}</div></> : null }
+                      <div className= "manager-response">{managerPollDays[managerPollDays.length-1].managerResponses[3]}</div></> : null }</> : null}
 
                   </div>
                     </> }


### PR DESCRIPTION
# Description

Manager polls now displaying for users; added checks to make sure users can't respond to polls until managers have responded to their polls first. Also allowed users to respond to polls that don't have manager questions toggled. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ x] There are no merge conflicts
