### PR TITLE
Update timepicker when update

### DIFF
--- a/client/src/pages/Reports/ModifyReports/EditReport.js
+++ b/client/src/pages/Reports/ModifyReports/EditReport.js
@@ -332,7 +332,7 @@ class EditReport extends Component {
                 <TimePicker
                   name="scheduleTime"
                   value={this.state.timePickDate}
-                  minutesStep={30}
+                  minutesStep={1}
                   onChange={this.timeChangeHandler}
                 />
               </section>


### PR DESCRIPTION
change it from 30 minute to 1 minute

# Description

Update timepicker when updating a report to be 1 minute instead of 30

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Change status
- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
